### PR TITLE
Update year in graphql playground query templates

### DIFF
--- a/src/main/resources/META-INF/resources/graphql/bestSellerList.graphql
+++ b/src/main/resources/META-INF/resources/graphql/bestSellerList.graphql
@@ -1,5 +1,5 @@
 {
-  bestSellerList(year: 2020) {
+  bestSellerList(year: 2024) {
     book {
       title
     }

--- a/src/main/resources/META-INF/resources/graphql/bestSellerListByCountry.graphql
+++ b/src/main/resources/META-INF/resources/graphql/bestSellerListByCountry.graphql
@@ -1,5 +1,5 @@
 {
-  bestSellerListByCountry(year: 2020, country: "us") {
+  bestSellerListByCountry(year: 2024, country: "us") {
     book {
       title
     }

--- a/src/main/resources/META-INF/resources/graphql/employeeOfTheYear.graphql
+++ b/src/main/resources/META-INF/resources/graphql/employeeOfTheYear.graphql
@@ -1,5 +1,5 @@
 {
-  employeeOfTheYear(year: 2020) {
+  employeeOfTheYear(year: 2024) {
     name
   }
 }

--- a/src/main/resources/META-INF/resources/graphql/purchasesOfForeigners.graphql
+++ b/src/main/resources/META-INF/resources/graphql/purchasesOfForeigners.graphql
@@ -1,5 +1,5 @@
 {
-  purchasesOfForeigners(year: 2020) { 
+  purchasesOfForeigners(year: 2024) { 
     total,
     shop {
       name,

--- a/src/main/resources/META-INF/resources/graphql/purchasesOfForeignersByCountry.graphql
+++ b/src/main/resources/META-INF/resources/graphql/purchasesOfForeignersByCountry.graphql
@@ -1,5 +1,5 @@
 {
-  purchasesOfForeignersByCountry(year: 2020, country: "us") { 
+  purchasesOfForeignersByCountry(year: 2024, country: "us") { 
     total,
     shop {
       name,


### PR DESCRIPTION
I found no way to use variables like {current-year} for this. Maybe there is another way...