### PR TITLE
Stop using deprecated Vaadin configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging.level:
   root: info
   org.atmosphere: warn
 
-vaadin.whitelisted-packages: com.vaadin,org.vaadin,org.eclipse,graphql
+vaadin.allowed-packages: com.vaadin,org.vaadin,org.eclipse,graphql
 
 logging.level.org.atmosphere: warn
  


### PR DESCRIPTION
More information:

https://github.com/vaadin/flow/blob/35a9e49c1e0776df8ef27dc2f19cfeb0c79ec577/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java#L537

```
/**
     * Set list of packages to be scanned. If <code>allowedPackages</code> is
     * set then <code>blockedPackages</code> is ignored.
     *
     * @param allowedPackages
     *            list of packages to be scanned
     * @deprecated use {@link #setAllowedPackages(List)}
     */
    @Deprecated(forRemoval = true)
    public void setWhitelistedPackages(List<String> allowedPackages) {
        this.allowedPackages = new ArrayList<>(allowedPackages);
    }
```